### PR TITLE
added synchronized keyword to navigate method

### DIFF
--- a/ui4j-webkit/src/main/java/io/webfolder/ui4j/webkit/WebKitBrowser.java
+++ b/ui4j-webkit/src/main/java/io/webfolder/ui4j/webkit/WebKitBrowser.java
@@ -285,7 +285,7 @@ class WebKitBrowser implements BrowserEngine {
     }
 
     @Override
-    public Page navigate(String url, PageConfiguration configuration) {
+    public synchronized Page navigate(String url, PageConfiguration configuration) {
         WebKitPageContext context = new WebKitPageContext(configuration);
 
         int pageId = pageCounter.incrementAndGet();


### PR DESCRIPTION
Fixes issue #65

Right now there are issues when multithreading using navigate method.  Simply adding synchronized keyword fixes issue.